### PR TITLE
get manifest information from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,10 +200,10 @@
         "wait-on": "6.0.0"
     },
     "manifest.webapp": {
-        "name": "DHIS2 Reports",
-        "description": "DHIS2 Reports",
+        "name": "NHWA Approval Report",
+        "description": "NHWA Approval Report",
         "icons": {
-            "48": "icon.png"
+            "48": "mal-icon.png"
         },
         "developer": {
             "url": "https://www.eyeseetea.com/",

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -10,7 +10,7 @@ export async function build(): Promise<void> {
     const report = process.env.REACT_APP_REPORT_VARIANT;
     console.debug(`Report type: ${report}`);
     console.debug("Building DHIS2 Approval Report");
-    run("yarn mal-build");
+    run("yarn nhwa-build");
 }
 
 async function main() {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699z5d42

### :memo: Implementation

- [x] modify build script to read app information from package.json

You can modify name, version or icon from the `manifest.webapp` section in the `package.json` file

### :video_camera: Screenshots/Screen capture

<img width="534" height="188" alt="Screenshot 2025-12-05 at 08 15 17" src="https://github.com/user-attachments/assets/bc31739c-07f3-475b-b743-e509fde8da1d" />


### :fire: Notes to the tester

#8699z5d42