### PR TITLE
Optional intermediate approval step gating the final Approve

### DIFF
--- a/docs/data-approval-user-guide.md
+++ b/docs/data-approval-user-guide.md
@@ -1,0 +1,185 @@
+# Data Approval — User Guide
+
+The **Data Approval** app (also known as *Data Approval Extended*) lets users review the status of dataset submissions across organisation units and periods, and take actions such as completing, submitting, approving or revoking data.
+
+This guide explains the main list, the filters, the row actions and the configuration options that control what each user can see and do.
+
+---
+
+## 1. The Data Approval list
+
+The main screen shows one row per **dataset / organisation unit / period** combination. Each row contains the following columns:
+
+| Column | Description |
+| --- | --- |
+| **Data set** | The name of the dataset being tracked. |
+| **Organisation unit** | The organisation unit that owns the data for that row. |
+| **Period** | The reporting period (e.g. month, quarter or year, depending on the dataset's period type). |
+| **Completion status** | Whether the dataset has been marked as *Completed* or is still *Not completed*. Marking a dataset as completed indicates that data entry for that period is finished. |
+| **Submission status** | Indicates whether the data has been *Submitted* (validated and ready for approval), is *Ready for submission* (completed but not yet submitted), or *Not submitted*. |
+| **Approval status** | Whether the data has been *Approved* by an authorised user or is still *Not approved*. |
+| **Intermediate approval status** | *(Optional, hidden by default)* Whether an intermediate approval has been granted for the row. Possible values: *Approved*, *Not approved*, or *N/A* when the dataset does not require an intermediate approval. See [Section 7](#7-intermediate-approval) for details. |
+| **Modification Count** | The number of data elements that have been modified since the last submission/approval. This is used to detect changes that may require a re-approval. See [Section 8](#8-data-element-groups-flag) for how this number is filtered when the *DataElementGroups* flag is enabled. |
+| **Last modification date** | The date and time of the most recent change to a data value in the dataset. Shows *No data* if the dataset has never been edited. |
+| **Last date of submission** | The date and time when the data was last submitted. Shows *Never submitted* when applicable. |
+| **Last date of approval** | The date and time when the data was last approved. Shows *Never approved* when applicable. |
+
+All dates are displayed in `yyyy-MM-dd HH:mm:ss` format.
+
+The gear icon at the top right of the list lets you show or hide columns and reorder them. The **Intermediate approval status** column is **hidden by default** — tick it in the column selector to display it.
+
+---
+
+## 2. Filters and the *Apply Filters* button
+
+A filter bar is displayed above the list. The available filters are:
+
+- **Period Type** — only shown when the configured datasets use more than one period type. Lets you switch between e.g. monthly, quarterly or yearly views.
+- **Data sets** — multi-select of the datasets configured for the app.
+- **Org Units** — hierarchical selector for one or more organisation units.
+- **Periods** — multi-select of the periods that are valid for the chosen period type.
+- **Completion status** — *Completed* or *Not completed*.
+- **Submission status** — *Submitted* or *Ready for submission*.
+- **Approval status** — *Approved* or *Not Approved*.
+- **Modification Count** — *0* (no changes) or *Greater than 0* (modified since last approval).
+
+### Apply Filters button
+
+Filter selections are **not** applied automatically. After changing any filter you must click **Apply Filters** for the list to be refreshed with the new criteria. This is intentional, because the underlying query can be expensive on large databases — clicking *Apply Filters* gives the user explicit control over when the request is sent.
+
+A **Clear filters** button is also available; it resets all filters back to their default empty values. The list is then re-queried the next time *Apply Filters* is pressed.
+
+---
+
+## 3. Analytics-running notice
+
+The Data Approval list relies on analytics tables to compute modification counts and other metrics. If the analytics process is currently running on the server, the list cannot be refreshed safely.
+
+When this happens, the app shows the following message in a red alert box and the table is not displayed:
+
+> **The list could not be loaded because analytics jobs are currently running. Please try again in a few seconds by clicking 'Apply Filters'.**
+
+When you see this message, simply wait until the analytics job finishes and click **Apply Filters** again to retry.
+
+---
+
+## 4. Contextual row actions
+
+When you select one or more rows in the list, a set of contextual actions becomes available. Each action is only enabled when it makes sense for the current state of the row(s) **and** when the current user has the corresponding permission (see [Section 6](#6-per-dataset-permission-groups)).
+
+| Action | What it does | When it is available |
+| --- | --- | --- |
+| **Complete** | Marks the dataset as *Completed* for the selected period and organisation unit. This signals that data entry is finished. | When the row is *Not completed* and contains data. |
+| **Incomplete** | Reverts a previously completed dataset back to *Not completed*. | When the row is *Completed* but has not yet been submitted. |
+| **Submit** | Submits the data for approval. After submission the row appears as *Submitted* / *Ready for approval*. | When the row has not been approved and contains data. |
+| **Intermediate Approve** | *(Optional — only on datasets with intermediate approval)* Grants an intermediate approval. See [Section 7](#7-intermediate-approval). | When the dataset requires intermediate approval, the user has permission, and the row is currently *Not approved* at the intermediate level. |
+| **Intermediate Unapprove** | *(Optional — only on datasets with intermediate approval)* Removes a previously granted intermediate approval. | When the dataset requires intermediate approval, the user has permission, the row is currently *Approved* at the intermediate level, and the final approval has not yet been granted. |
+| **Approve** | Approves the submitted data. After approval the row appears as *Approved* and the *Last date of approval* is set. | When the row has been modified and is *Not approved*. If the dataset requires an intermediate approval, this action is only available once the intermediate approval is in place (see [Section 7](#7-intermediate-approval)). |
+| **Revoke** | Removes a previous approval, returning the row to *Not approved*. On datasets with intermediate approval, Revoke also resets the intermediate approval state back to *Not approved*. | When the row is currently *Approved*. |
+
+In addition, a **Check Difference** action is available to see exactly which data elements have been modified since the last approval. This is useful before re-approving a dataset that has a *Modification Count* greater than zero.
+
+---
+
+## 5. Dataset configuration
+
+Each dataset handled by the app has a configuration entry that tells the app:
+
+- Which underlying dataset to read from (**Data set**) and which approval dataset to write approval metadata to (**Data set Approval**).
+- Which data element to use to store the **Submit date** and which one for the **Approval date**, both inside the approval dataset.
+- Which SQL views to use as data sources for the list (one for current periods, one for old periods).
+- Whether **Submit also approves the dataSet** and whether **Revoke also marks the dataSet as incomplete**.
+- *(Optional)* Whether **Intermediate approval required** is enabled and, if so, which data element stores the intermediate approval flag.
+- Which user groups/users are allowed to perform each action.
+
+The *Intermediate approve DataElement* field in the configuration form is disabled while *Intermediate approval required* is unchecked — ticking the flag enables the selector so you can pick the Yes/No data element used to track the intermediate state (see [Section 7](#7-intermediate-approval)).
+
+---
+
+## 6. Per-dataset permission groups
+
+For each dataset configured in the app, an administrator can independently control **who** is allowed to perform each action. This is done from the dataset configuration screen, where the following permission categories are available:
+
+- **Read** — who can see the dataset's rows in the Data Approval list.
+- **Complete** — who can use the *Complete* action.
+- **Incomplete** — who can use the *Incomplete* action.
+- **Submit** — who can use the *Submit* action.
+- **Revoke** — who can use the *Revoke* action.
+- **Intermediate Approve** — who can use the *Intermediate Approve* / *Intermediate Unapprove* actions. *(Optional — only relevant when the dataset has Intermediate approval required.)*
+- **Approve** — who can use the *Approve* action.
+
+For each category, the administrator can grant access to:
+
+- One or more **user groups**, and/or
+- One or more **individual users**.
+
+When a user opens the Data Approval list, the app checks their group membership and username against these permission lists. Any action the user does not have permission for will be hidden or disabled on the corresponding rows. Super-administrators bypass these checks and always see every action for every dataset.
+
+This makes it possible, for example, to let a wide group of data clerks *Complete* and *Submit* data, a smaller group of reviewers perform *Intermediate Approve*, and an even smaller group of supervisors perform the final *Approve* and *Revoke*.
+
+---
+
+## 7. Intermediate approval
+
+For datasets where a final approval should only be possible after a **first‑level review** has taken place, the app supports an optional intermediate approval step. It is configured per dataset and disabled by default.
+
+### 7.1 Configuration
+
+On the dataset configuration form, an administrator can turn on **Intermediate approval required** and pick an *Intermediate Approve DataElement*. This must be a Yes/No (boolean) data element that lives in the **approval dataset** (APVD) of that configuration. The app stores the intermediate state on that data element per organisation unit and period.
+
+A separate **Intermediate Approve** permission group is also available on the configuration form, so administrators can list which user groups/users are allowed to use the *Intermediate Approve* and *Intermediate Unapprove* actions.
+
+When the flag is **off** for a dataset, nothing changes: the *Intermediate approval status* column shows *N/A*, the intermediate actions are hidden, and the existing *Approve* action works exactly as described in earlier sections.
+
+### 7.2 The Intermediate approval status column
+
+When the flag is **on**, the *Intermediate approval status* column (hidden by default — enable it from the column selector) reflects the **effective** intermediate state:
+
+- **Approved** — the intermediate data element is set to *Yes* **and** there are no pending modifications (*Modification Count = 0*).
+- **Not approved** — the intermediate data element is *No*, empty, **or** there are pending modifications that invalidate a previously granted intermediate approval.
+- **N/A** — this dataset does not require an intermediate approval.
+
+The modification‑count check is purely derivational: if somebody edits a data value after an intermediate approval has been granted, the list automatically shows *Not approved* in this column and gates the *Approve* action accordingly. The stored data element value is not touched — to re‑affirm the approval after a modification, the user simply runs *Intermediate Approve* again.
+
+### 7.3 The intermediate actions
+
+Two new actions appear in the contextual menu when the dataset requires intermediate approval and the user has the *Intermediate Approve* permission:
+
+- **Intermediate Approve** — writes *true* to the configured intermediate data element for every selected row (default category option combo). It is only offered when the row has data, is currently *Not approved* at the intermediate level, and has a non‑zero modification count. Multiple rows can be selected.
+- **Intermediate Unapprove** — writes *false* to the same data element. Offered when the stored intermediate value is currently *Yes* and the final approval has **not** been granted yet (to undo a final approval first, use *Revoke*). Multiple rows can be selected.
+
+### 7.4 How Intermediate approval gates the final *Approve*
+
+When a dataset requires intermediate approval, the *Approve* action in the contextual menu is only available when **every** selected row has *effective intermediate status = Approved*:
+
+- On a single row where the intermediate step has not been done, *Approve* is hidden.
+- On a multi‑select where at least one of the selected rows has not been intermediate‑approved, *Approve* is hidden entirely (even if some of the other selected rows are eligible).
+- When the flag is off for that dataset, *Approve* works as before.
+
+### 7.5 Interaction with Revoke
+
+Running **Revoke** on a row with intermediate approval has a cascading effect: the app revokes the final approval **and** resets the intermediate approval back to *No*. The reviewer therefore has to re‑grant the intermediate approval before *Approve* can be run again. This ensures the approval chain is always fully re‑played whenever a row goes back to an editable state.
+
+---
+
+## 8. Data Element Groups flag
+
+Each dataset configuration has an optional flag — **Restrict modification display by Data Element Group sharing** — that changes how the *Modification Count* and *Check Difference* features behave.
+
+- **When the flag is OFF (default):** all data elements in the dataset are considered when calculating the modification count. Every change to any data element since the last approval increases the count.
+
+- **When the flag is ON:** the app only considers data elements that belong to a **Data Element Group** to which the current user has *read* access (either directly or through one of their user groups). Changes to data elements outside those groups are ignored both in the modification count and in the *Check Difference* dialog.
+
+This is useful in deployments where different teams are responsible for different subsets of the data elements within a single dataset: each team only sees changes that are relevant to them, and is not alerted to modifications they have no business reviewing.
+
+Super-administrators bypass this restriction and always see the unfiltered modification count.
+
+---
+
+## Quick reference: typical workflow
+
+1. **Filter** the list down to the datasets, organisation units and periods you are interested in, then click **Apply Filters**.
+2. Look at the **Completion**, **Submission** and **Approval** status columns to find the rows that need attention. If the dataset uses intermediate approval, show the **Intermediate approval status** column from the gear menu to see where each row stands.
+3. If a row has a non-zero **Modification Count**, use **Check Difference** to inspect what changed.
+4. Select the rows and run the appropriate contextual action: **Complete**, **Submit**, **Intermediate Approve** (if configured), **Approve**, or — when needed — **Incomplete** / **Intermediate Unapprove** / **Revoke**.
+5. If the list refuses to refresh because analytics are running, wait a few seconds and click **Apply Filters** again.

--- a/src/data/DataSetConfigurationD2Repository.ts
+++ b/src/data/DataSetConfigurationD2Repository.ts
@@ -1,4 +1,4 @@
-import { DataSetConfiguration } from "../domain/entities/DataSetConfiguration";
+import { DataSetConfiguration, DataSetConfigurationAttrs } from "../domain/entities/DataSetConfiguration";
 import { Future, FutureData } from "../domain/generic/Future";
 import { DataSetConfigurationRepository } from "../domain/repositories/DataSetConfigurationRepository";
 import { D2Api } from "../types/d2-api";
@@ -16,9 +16,9 @@ export class DataSetConfigurationD2Repository implements DataSetConfigurationRep
 
     getByCode(code: string): FutureData<DataSetConfiguration> {
         const dataStore = this.api.dataStore(this.namespace);
-        return apiToFuture(dataStore.get<DataSetConfiguration>(`DS_${code}`)).flatMap(data => {
+        return apiToFuture(dataStore.get<Partial<DataSetConfigurationAttrs>>(`DS_${code}`)).flatMap(data => {
             return data
-                ? Future.success(DataSetConfiguration.create(data))
+                ? Future.success(DataSetConfiguration.withDefaults(data))
                 : Future.error(new Error(`DataSetConfiguration with code ${code} not found`));
         });
     }
@@ -35,7 +35,7 @@ export class DataSetConfigurationD2Repository implements DataSetConfigurationRep
                 entry.key.startsWith(DataSetConfiguration.CODE_PREFIX)
             );
             return onlyDataSetConfigs.map(entry => {
-                return DataSetConfiguration.create(entry.value);
+                return DataSetConfiguration.withDefaults(entry.value);
             });
         });
     }
@@ -55,6 +55,6 @@ type D2DataStoreFields = {
     entries: D2Entries[];
 };
 
-type D2Entries = { key: string; value: DataSetConfiguration };
+type D2Entries = { key: string; value: Partial<DataSetConfigurationAttrs> };
 
 const dataStoreFields = { fields: "." };

--- a/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
+++ b/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
@@ -114,7 +114,9 @@ type SqlField =
     | "diff"
     | "monitoring";
 
-const fieldMapping: Record<keyof MalDataApprovalItem, SqlField> = {
+// Not every item field is backed by a SQL view column — "intermediateApproved"
+// is fetched via a separate /dataValueSets call and has no SQL mapping.
+const fieldMapping: Partial<Record<keyof MalDataApprovalItem, SqlField>> = {
     dataSetUid: "datasetuid",
     dataSet: "dataset",
     orgUnitUid: "orgunit",
@@ -176,7 +178,7 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
             dataSets: dataSetId,
             completed: completionStatus === undefined ? "-" : completionStatus ? "true" : "-",
             approved: approvalStatus === undefined ? "-" : approvalStatus.toString(),
-            orderByColumn: fieldMapping[sorting.field],
+            orderByColumn: fieldMapping[sorting.field] ?? "period",
             orderByDirection: sorting.direction,
         };
 
@@ -909,6 +911,71 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
 
             return _.every(response, item => item === "");
         } catch (error: any) {
+            return false;
+        }
+    }
+
+    async setIntermediateApproval(options: {
+        dataSets: MalDataApprovalItemIdentifier[];
+        dataSetConfig: DataSetWithConfigPermissions;
+        approved: boolean;
+    }): Promise<boolean> {
+        const { dataSets, dataSetConfig, approved } = options;
+        const intermediateApproveCode = dataSetConfig.configuration.intermediateApproveCode;
+        if (!intermediateApproveCode) return false;
+
+        try {
+            const DEFAULT_COC = (await this.getDefaultCombination()).id;
+            const dataElement = await getMetadataByIdentifiableToken({
+                api: this.api,
+                metadataType: "dataElements",
+                token: intermediateApproveCode,
+            });
+
+            const dataValues = dataSets.map(ds => ({
+                dataSet: ds.dataSet,
+                period: ds.period,
+                orgUnit: ds.orgUnit,
+                dataElement: dataElement.id,
+                categoryOptionCombo: DEFAULT_COC,
+                value: approved ? "true" : "false",
+            }));
+
+            const response = await this.api.post<any>("/dataValueSets.json", {}, { dataValues }).getData();
+            return response.response?.status === "SUCCESS" || response.status === "SUCCESS";
+        } catch (error: any) {
+            console.debug(error);
+            return false;
+        }
+    }
+
+    async getIntermediateApproval(options: {
+        item: MalDataApprovalItemIdentifier;
+        dataSetConfig: DataSetWithConfigPermissions;
+    }): Promise<boolean> {
+        const { item, dataSetConfig } = options;
+        const intermediateApproveCode = dataSetConfig.configuration.intermediateApproveCode;
+        if (!intermediateApproveCode) return false;
+
+        try {
+            const dataElement = await getMetadataByIdentifiableToken({
+                api: this.api,
+                metadataType: "dataElements",
+                token: intermediateApproveCode,
+            });
+
+            const response = await this.api
+                .get<{ dataValues?: { dataElement: string; value: string }[] }>("/dataValueSets", {
+                    dataSet: item.dataSet,
+                    period: item.period,
+                    orgUnit: item.orgUnit,
+                })
+                .getData();
+
+            const matching = response.dataValues?.find(dv => dv.dataElement === dataElement.id);
+            return matching?.value === "true";
+        } catch (error: any) {
+            console.debug(error);
             return false;
         }
     }

--- a/src/domain/entities/DataSetConfiguration.ts
+++ b/src/domain/entities/DataSetConfiguration.ts
@@ -26,6 +26,8 @@ export type DataSetConfigurationAttrs = {
     oldDataSourceId: Id;
     submitAndComplete: boolean;
     revokeAndIncomplete: boolean;
+    intermediateApprovalRequired: boolean;
+    intermediateApproveCode: string;
 };
 
 export class DataSetConfiguration extends Struct<DataSetConfigurationAttrs>() {
@@ -48,6 +50,17 @@ export class DataSetConfiguration extends Struct<DataSetConfigurationAttrs>() {
             oldDataSourceId: "",
             submitAndComplete: false,
             revokeAndIncomplete: false,
+            intermediateApprovalRequired: false,
+            intermediateApproveCode: "",
+        });
+    }
+
+    static withDefaults(attrs: Partial<DataSetConfigurationAttrs>): DataSetConfiguration {
+        const defaults = DataSetConfiguration.initial()._getAttributes();
+        return new DataSetConfiguration({
+            ...defaults,
+            ...attrs,
+            permissions: { ...defaults.permissions, ...(attrs.permissions ?? {}) },
         });
     }
 
@@ -88,6 +101,14 @@ export class DataSetConfiguration extends Struct<DataSetConfigurationAttrs>() {
 
     updateRevokeAndIncomplete(value: boolean): DataSetConfiguration {
         return this._update({ revokeAndIncomplete: value });
+    }
+
+    updateIntermediateApprovalRequired(value: boolean): DataSetConfiguration {
+        return this._update({ intermediateApprovalRequired: value });
+    }
+
+    updateIntermediateApproveDataElement(newDataElementCode: string): DataSetConfiguration {
+        return this._update({ intermediateApproveCode: newDataElementCode });
     }
 
     hasPermission(action: DataSetConfigurationAction, username: string, userGroupCodes: Code[]): boolean {
@@ -145,11 +166,20 @@ export class DataSetConfiguration extends Struct<DataSetConfigurationAttrs>() {
             revoke: DataSetConfiguration.EMPTY_PERMISSIONS,
             submit: DataSetConfiguration.EMPTY_PERMISSIONS,
             approve: DataSetConfiguration.EMPTY_PERMISSIONS,
+            intermediateApprove: DataSetConfiguration.EMPTY_PERMISSIONS,
         };
     }
 }
 
-export const dataSetConfigurationActions = ["read", "complete", "incomplete", "submit", "revoke", "approve"] as const;
+export const dataSetConfigurationActions = [
+    "read",
+    "complete",
+    "incomplete",
+    "submit",
+    "revoke",
+    "intermediateApprove",
+    "approve",
+] as const;
 
 export type DataSetConfigurationAction = typeof dataSetConfigurationActions[number];
 type DataSetConfigurationError = ValidationError<DataSetConfigurationAttrs>;

--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -18,6 +18,9 @@ export interface MalDataApprovalItem {
     lastDateOfApproval: string | undefined;
     modificationCount: string | undefined;
     monitoring: boolean;
+    // Raw stored value of the "intermediate approve" data element for this row, or
+    // undefined when the feature isn't configured / hasn't been fetched.
+    intermediateApproved?: boolean;
 }
 
 export interface MalDataApprovalItemIdentifier {

--- a/src/domain/reports/mal-data-approval/repositories/MalDataApprovalRepository.ts
+++ b/src/domain/reports/mal-data-approval/repositories/MalDataApprovalRepository.ts
@@ -35,6 +35,15 @@ export interface MalDataApprovalRepository {
     ): Promise<boolean>;
     incomplete(dataSets: MalDataApprovalItemIdentifier[]): Promise<boolean>;
     unapprove(dataSets: MalDataApprovalItemIdentifier[]): Promise<boolean>;
+    setIntermediateApproval(options: {
+        dataSets: MalDataApprovalItemIdentifier[];
+        dataSetConfig: DataSetWithConfigPermissions;
+        approved: boolean;
+    }): Promise<boolean>;
+    getIntermediateApproval(options: {
+        item: MalDataApprovalItemIdentifier;
+        dataSetConfig: DataSetWithConfigPermissions;
+    }): Promise<boolean>;
     getColumns(namespace: string): Promise<string[]>;
     saveColumns(namespace: string, columns: string[]): Promise<void>;
     getSortOrder(): Promise<string[]>;

--- a/src/domain/reports/mal-data-approval/usecases/GetMalDataSetsUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/GetMalDataSetsUseCase.ts
@@ -25,6 +25,12 @@ export class GetMalDataSetsUseCase implements UseCase {
             const { dataSetIds: _, ...rest } = options;
             const result = await this.malDataRepository.get({ ...rest, dataSetId: dataSetId });
 
+            const dataSetConfig = options.dataSetsConfig.find(ds => ds.dataSet.id === dataSetId);
+            const intermediateEnabled = Boolean(
+                dataSetConfig?.configuration.intermediateApprovalRequired &&
+                    dataSetConfig?.configuration.intermediateApproveCode
+            );
+
             const response = await promiseMap(result.objects, async item => {
                 const dataElementsWithValues = await new WmrDiffReport(
                     this.dataValueRepository,
@@ -32,11 +38,26 @@ export class GetMalDataSetsUseCase implements UseCase {
                     options.dataSetsConfig
                 ).getDiff(item.dataSetUid, item.orgUnitUid, item.period);
 
+                const intermediateApproved =
+                    intermediateEnabled && dataSetConfig
+                        ? await this.malDataRepository.getIntermediateApproval({
+                              item: {
+                                  dataSet: item.dataSetUid,
+                                  orgUnit: item.orgUnitUid,
+                                  orgUnitCode: item.orgUnitCode,
+                                  period: item.period,
+                                  workflow: item.approvalWorkflowUid,
+                              },
+                              dataSetConfig,
+                          })
+                        : undefined;
+
                 return {
                     ...item,
                     // TODO: remove all monitoring related code
                     monitoring: false,
                     modificationCount: dataElementsWithValues.length > 0 ? String(dataElementsWithValues.length) : "",
+                    intermediateApproved: intermediateApproved,
                 };
             });
 

--- a/src/domain/reports/mal-data-approval/usecases/UpdateMalApprovalStatusUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/UpdateMalApprovalStatusUseCase.ts
@@ -53,14 +53,33 @@ export class UpdateMalApprovalStatusUseCase {
                 }
                 case "revoke": {
                     const revokeResult = await this.approvalRepository.unapprove(itemsToUpdate);
+                    const resetIntermediateResult = config.configuration.intermediateApprovalRequired
+                        ? await this.approvalRepository.setIntermediateApproval({
+                              dataSets: itemsToUpdate,
+                              dataSetConfig: config,
+                              approved: false,
+                          })
+                        : true;
                     if (config.configuration.revokeAndIncomplete) {
                         const incompleteResult = await this.approvalRepository.incomplete(itemsToUpdate);
-                        return revokeResult && incompleteResult;
+                        return revokeResult && resetIntermediateResult && incompleteResult;
                     }
-                    return revokeResult;
+                    return revokeResult && resetIntermediateResult;
                 }
                 case "incomplete":
                     return this.approvalRepository.incomplete(itemsToUpdate);
+                case "intermediateApprove":
+                    return this.approvalRepository.setIntermediateApproval({
+                        dataSets: itemsToUpdate,
+                        dataSetConfig: config,
+                        approved: true,
+                    });
+                case "intermediateUnapprove":
+                    return this.approvalRepository.setIntermediateApproval({
+                        dataSets: itemsToUpdate,
+                        dataSetConfig: config,
+                        approved: false,
+                    });
                 default:
                     return false;
             }
@@ -113,6 +132,8 @@ type UpdateAction =
     | "unapprove"
     | "activate"
     | "deactivate"
-    | "revoke";
+    | "revoke"
+    | "intermediateApprove"
+    | "intermediateUnapprove";
 
 export type Log = (msg: string) => void;

--- a/src/webapp/components/dataset-config/DataSetConfigForm.tsx
+++ b/src/webapp/components/dataset-config/DataSetConfigForm.tsx
@@ -39,11 +39,13 @@ export const DataSetConfigForm: React.FC<DataSetConfigFormProps> = props => {
         onChange(newConfiguration);
     };
 
-    const updateDataElement = (code: string, type: "submit" | "approval") => {
+    const updateDataElement = (code: string, type: "submit" | "approval" | "intermediateApprove") => {
         const newConfiguration =
             type === "submit"
                 ? configuration.updateSubmissionDateDataElement(code)
-                : configuration.updateApprovalDateDataElement(code);
+                : type === "approval"
+                ? configuration.updateApprovalDateDataElement(code)
+                : configuration.updateIntermediateApproveDataElement(code);
         onChange(newConfiguration);
     };
 
@@ -145,9 +147,29 @@ export const DataSetConfigForm: React.FC<DataSetConfigFormProps> = props => {
                         />
                         {i18n.t("Revoke also marks dataSet as incomplete")}
                     </Grid>
+                    <Grid item xs={6}>
+                        <Checkbox
+                            checked={configuration.intermediateApprovalRequired}
+                            onChange={e => {
+                                onChange(configuration.updateIntermediateApprovalRequired(e.target.checked));
+                            }}
+                        />
+                        {i18n.t("Intermediate approval required")}
+                    </Grid>
+                    <Grid item xs={6}>
+                        <EntitySelector
+                            type="dataElements"
+                            label={i18n.t("Intermediate Approve DataElement")}
+                            value={configuration.intermediateApproveCode}
+                            onChange={entity => updateDataElement(entity.code, "intermediateApprove")}
+                            onlyWithCode
+                            disabled={!configuration.intermediateApprovalRequired}
+                        />
+                    </Grid>
                     <div className={classes.permissionContainer}>
                         {dataSetConfigurationActions.map(action => {
                             const { userGroups, users } = configuration.permissions[action];
+                            const label = actionLabels[action];
 
                             return (
                                 <div key={action} className={classes.permissionItem}>
@@ -158,10 +180,10 @@ export const DataSetConfigForm: React.FC<DataSetConfigFormProps> = props => {
                                         fullWidth
                                         size="small"
                                     >
-                                        {i18n.t('Edit "{{action}}" Permissions', { action })}
+                                        {i18n.t('Edit "{{action}}" Permissions', { action: label })}
                                     </Button>
                                     <PermissionsSharing
-                                        title={action}
+                                        title={label}
                                         visible={selectedPermission === action}
                                         usernames={users}
                                         userGroupCodes={userGroups}
@@ -192,6 +214,16 @@ export const DataSetConfigForm: React.FC<DataSetConfigFormProps> = props => {
             </form>
         </Paper>
     );
+};
+
+const actionLabels: Record<DataSetConfigurationAction, string> = {
+    read: "read",
+    complete: "complete",
+    incomplete: "incomplete",
+    submit: "submit",
+    revoke: "revoke",
+    approve: "approve",
+    intermediateApprove: "intermediate approve",
 };
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/src/webapp/components/entity-selector/EntitySelector.tsx
+++ b/src/webapp/components/entity-selector/EntitySelector.tsx
@@ -18,16 +18,18 @@ type EntitySelectorProps = {
     type: MetadataEntityType;
     onChange: (entity: TableEntity) => void;
     onlyWithCode?: boolean;
+    disabled?: boolean;
 };
 
 export const EntitySelector = (props: EntitySelectorProps) => {
-    const { label, onChange, value, type, onlyWithCode } = props;
+    const { label, onChange, value, type, onlyWithCode, disabled } = props;
     const [showModal, setShowModal] = React.useState(false);
     const [selectedEntity, setSelectedEntity] = React.useState<TableEntity>();
 
     const openTable = React.useCallback(() => {
+        if (disabled) return;
         setShowModal(true);
-    }, []);
+    }, [disabled]);
 
     const selectEntity = React.useCallback(
         (entity: TableEntity) => {
@@ -46,6 +48,7 @@ export const EntitySelector = (props: EntitySelectorProps) => {
                 label={label}
                 value={selectedEntity ? selectedEntity.code ?? selectedEntity.name : value}
                 inputProps={{ readOnly: true }}
+                disabled={disabled}
                 fullWidth
             />
             <ConfirmationDialog

--- a/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
+++ b/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
@@ -3,6 +3,9 @@ import {
     getDataDuplicationItemId,
 } from "../../../domain/reports/mal-data-approval/entities/MalDataApprovalItem";
 import { toDate, zonedTimeToUtc, utcToZonedTime } from "date-fns-tz";
+import { DataSetWithConfigPermissions } from "../../../domain/usecases/GetApprovalConfigurationsUseCase";
+
+export type IntermediateApprovalStatus = "approved" | "notApproved" | "na";
 
 export interface DataApprovalViewModel {
     id: string;
@@ -22,32 +25,56 @@ export interface DataApprovalViewModel {
     modificationCount: string | undefined;
     monitoring: boolean;
     approved: boolean | undefined;
+    intermediateApprovalRequired: boolean;
+    intermediateApproved: boolean;
+    effectiveIntermediateApproval: IntermediateApprovalStatus;
 }
 
-export function getDataApprovalViews(items: MalDataApprovalItem[], timeZoneId: string): DataApprovalViewModel[] {
-    return items.map(item => ({
-        id: getDataDuplicationItemId(item),
-        dataSetUid: item.dataSetUid,
-        dataSet: item.dataSet,
-        orgUnitUid: item.orgUnitUid,
-        orgUnit: item.orgUnit,
-        period: item.period,
-        attribute: item.attribute ?? "-",
-        approvalWorkflowUid: item.approvalWorkflowUid ?? "-",
-        approvalWorkflow: item.approvalWorkflow ?? "-",
-        completed: item.completed,
-        validated: item.validated,
-        lastUpdatedValue: item.lastUpdatedValue
-            ? convertToUserTime({ serverDate: item.lastUpdatedValue, timeZoneId })
-            : undefined,
-        lastDateOfSubmission: item.lastDateOfSubmission
-            ? toDate(item.lastDateOfSubmission, { timeZone: "UTC" })
-            : undefined,
-        lastDateOfApproval: item.lastDateOfApproval ? toDate(item.lastDateOfApproval, { timeZone: "UTC" }) : undefined,
-        modificationCount: item.modificationCount,
-        monitoring: item.monitoring,
-        approved: item.approved,
-    }));
+export function getDataApprovalViews(
+    items: MalDataApprovalItem[],
+    timeZoneId: string,
+    dataSetsConfig: DataSetWithConfigPermissions[]
+): DataApprovalViewModel[] {
+    return items.map(item => {
+        const config = dataSetsConfig.find(ds => ds.dataSet.id === item.dataSetUid);
+        const intermediateApprovalRequired = Boolean(config?.configuration.intermediateApprovalRequired);
+        const intermediateApproved = Boolean(item.intermediateApproved);
+        const hasModifications = Boolean(item.modificationCount);
+        const effectiveIntermediateApproval: IntermediateApprovalStatus = !intermediateApprovalRequired
+            ? "na"
+            : intermediateApproved && !hasModifications
+            ? "approved"
+            : "notApproved";
+
+        return {
+            id: getDataDuplicationItemId(item),
+            dataSetUid: item.dataSetUid,
+            dataSet: item.dataSet,
+            orgUnitUid: item.orgUnitUid,
+            orgUnit: item.orgUnit,
+            period: item.period,
+            attribute: item.attribute ?? "-",
+            approvalWorkflowUid: item.approvalWorkflowUid ?? "-",
+            approvalWorkflow: item.approvalWorkflow ?? "-",
+            completed: item.completed,
+            validated: item.validated,
+            lastUpdatedValue: item.lastUpdatedValue
+                ? convertToUserTime({ serverDate: item.lastUpdatedValue, timeZoneId })
+                : undefined,
+            lastDateOfSubmission: item.lastDateOfSubmission
+                ? toDate(item.lastDateOfSubmission, { timeZone: "UTC" })
+                : undefined,
+            lastDateOfApproval: item.lastDateOfApproval
+                ? toDate(item.lastDateOfApproval, { timeZone: "UTC" })
+                : undefined,
+            modificationCount: item.modificationCount,
+            monitoring: item.monitoring,
+            approved: item.approved,
+            intermediateApprovalRequired: intermediateApprovalRequired,
+            intermediateApproved: intermediateApproved,
+            effectiveIntermediateApproval: effectiveIntermediateApproval,
+        };
+    });
 }
 
 export const convertToUserTime = ({ serverDate, timeZoneId }: { serverDate: string; timeZoneId: string }): Date => {

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -22,7 +22,7 @@ import { ConfirmationDialog } from "@eyeseetea/d2-ui-components";
 import { DataApprovalViewModel, getDataApprovalViews } from "../DataApprovalViewModel";
 import { DataSetsFilter, Filters } from "./Filters";
 import { DataDifferencesList } from "../DataDifferencesList";
-import { PlaylistAddCheck, ThumbUp } from "@material-ui/icons";
+import { PlaylistAddCheck, ThumbUp, ThumbUpAltOutlined, ThumbDownAltOutlined } from "@material-ui/icons";
 import { Namespaces } from "../../../../data/common/clients/storage/Namespaces";
 import { emptyApprovalFilter } from "./hooks/useDataApprovalFilters";
 import { useDataApprovalListColumns } from "./hooks/useDataApprovalListColumns";
@@ -113,6 +113,22 @@ export const DataApprovalList: React.FC<{ dataSetsConfig: DataSetWithConfigPermi
                         isActive: activeActions.isRevokeActionVisible,
                     },
                     {
+                        name: "intermediateApprove",
+                        text: i18n.t("Intermediate Approve"),
+                        icon: <ThumbUpAltOutlined />,
+                        multiple: true,
+                        onClick: onTableActionClick.intermediateApproveAction,
+                        isActive: activeActions.isIntermediateApproveActionVisible,
+                    },
+                    {
+                        name: "intermediateUnapprove",
+                        text: i18n.t("Intermediate Unapprove"),
+                        icon: <ThumbDownAltOutlined />,
+                        multiple: true,
+                        onClick: onTableActionClick.intermediateUnapproveAction,
+                        isActive: activeActions.isIntermediateUnapproveActionVisible,
+                    },
+                    {
                         name: "approve",
                         text: i18n.t("Approve"),
                         icon: <ThumbUp />,
@@ -145,12 +161,16 @@ export const DataApprovalList: React.FC<{ dataSetsConfig: DataSetWithConfigPermi
                 onTableActionClick.revokeAction,
                 onTableActionClick.approveAction,
                 onTableActionClick.getDifferenceAction,
+                onTableActionClick.intermediateApproveAction,
+                onTableActionClick.intermediateUnapproveAction,
                 activeActions.isCompleteActionVisible,
                 activeActions.isIncompleteActionVisible,
                 activeActions.isSubmitActionVisible,
                 activeActions.isRevokeActionVisible,
                 activeActions.isApproveActionVisible,
                 activeActions.isGetDifferenceActionVisible,
+                activeActions.isIntermediateApproveActionVisible,
+                activeActions.isIntermediateUnapproveActionVisible,
             ]
         );
 
@@ -171,7 +191,7 @@ export const DataApprovalList: React.FC<{ dataSetsConfig: DataSetWithConfigPermi
                     if (isCancelled) return;
 
                     console.debug("Reloading", reloadKey);
-                    setRows(getDataApprovalViews(objects, config.timeZoneId));
+                    setRows(getDataApprovalViews(objects, config.timeZoneId, dataSetsConfig));
                     setIsLoading(false);
                     setError(undefined);
                 } catch (err) {
@@ -292,9 +312,35 @@ export const DataApprovalList: React.FC<{ dataSetsConfig: DataSetWithConfigPermi
     }
 );
 
+const sortableMalItemFields: Record<keyof MalDataApprovalItem, true> = {
+    dataSetUid: true,
+    dataSet: true,
+    orgUnitUid: true,
+    orgUnit: true,
+    orgUnitCode: true,
+    period: true,
+    attribute: true,
+    approvalWorkflowUid: true,
+    approvalWorkflow: true,
+    completed: true,
+    validated: true,
+    approved: true,
+    lastUpdatedValue: true,
+    lastDateOfSubmission: true,
+    lastDateOfApproval: true,
+    modificationCount: true,
+    monitoring: true,
+    intermediateApproved: true,
+};
+
 function getSortingFromTableSorting(sorting: TableSorting<DataApprovalViewModel>): Sorting<MalDataApprovalItem> {
+    const field = sorting.field;
+    const malItemField =
+        field !== "id" && (sortableMalItemFields as Record<string, boolean>)[field as string]
+            ? (field as keyof MalDataApprovalItem)
+            : ("period" as const);
     return {
-        field: sorting.field === "id" ? "period" : sorting.field,
+        field: malItemField,
         direction: sorting.order,
     };
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useActiveDataApprovalActions.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useActiveDataApprovalActions.tsx
@@ -15,6 +15,8 @@ type ActiveDataApprovalActionsState = {
     isIncompleteActionVisible: (rows: DataApprovalViewModel[]) => boolean;
     isRevokeActionVisible: (rows: DataApprovalViewModel[]) => boolean;
     isSubmitActionVisible: (rows: DataApprovalViewModel[]) => boolean;
+    isIntermediateApproveActionVisible: (rows: DataApprovalViewModel[]) => boolean;
+    isIntermediateUnapproveActionVisible: (rows: DataApprovalViewModel[]) => boolean;
 };
 
 export function getDataSetAccess(options: {
@@ -49,9 +51,53 @@ export function useActiveDataApprovalActions(props: {
                     dataSetsConfig,
                     dataSetId: row.dataSetUid,
                 });
-                return row.lastUpdatedValue && Number(row.modificationCount) > 0 && hasAccess;
+                // When a dataset requires intermediate approval, the final Approve
+                // action is only offered once the effective intermediate state is
+                // "approved" (stored Yes AND no pending modifications). See the
+                // derivation in getDataApprovalViews. When the flag is off, the
+                // effective status is "na" and Approve behaves as before.
+                const intermediateGateOk =
+                    row.effectiveIntermediateApproval === "na" || row.effectiveIntermediateApproval === "approved";
+                return row.lastUpdatedValue && Number(row.modificationCount) > 0 && hasAccess && intermediateGateOk;
             });
         },
+        [config.currentUser, dataSetsConfig]
+    );
+
+    const isIntermediateApproveActionVisible = useCallback(
+        (rows: DataApprovalViewModel[]) =>
+            _.every(rows, row => {
+                const hasAccess = getDataSetAccess({
+                    action: "intermediateApprove",
+                    user: config.currentUser,
+                    dataSetsConfig,
+                    dataSetId: row.dataSetUid,
+                });
+                return (
+                    row.intermediateApprovalRequired &&
+                    row.effectiveIntermediateApproval === "notApproved" &&
+                    row.lastUpdatedValue &&
+                    Number(row.modificationCount) > 0 &&
+                    Boolean(hasAccess)
+                );
+            }),
+        [config.currentUser, dataSetsConfig]
+    );
+
+    const isIntermediateUnapproveActionVisible = useCallback(
+        (rows: DataApprovalViewModel[]) =>
+            _.every(rows, row => {
+                const hasAccess = getDataSetAccess({
+                    action: "intermediateApprove",
+                    user: config.currentUser,
+                    dataSetsConfig,
+                    dataSetId: row.dataSetUid,
+                });
+                // Unapprove is offered when the stored value is Yes (regardless of
+                // modifications masking it), but not once the final Approve has landed —
+                // the user must Revoke first in that case.
+                return row.intermediateApprovalRequired && row.intermediateApproved && !row.approved && Boolean(hasAccess);
+            }),
         [config.currentUser, dataSetsConfig]
     );
 
@@ -155,5 +201,7 @@ export function useActiveDataApprovalActions(props: {
         isIncompleteActionVisible: isIncompleteActionVisible,
         isRevokeActionVisible: isRevokeActionVisible,
         isSubmitActionVisible: isSubmitActionVisible,
+        isIntermediateApproveActionVisible: isIntermediateApproveActionVisible,
+        isIntermediateUnapproveActionVisible: isIntermediateUnapproveActionVisible,
     };
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalActions.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalActions.tsx
@@ -37,6 +37,8 @@ type DataApprovalActionsState = {
         incompleteAction: (selectedIds: string[]) => Promise<void>;
         revokeAction: (selectedIds: string[]) => Promise<void>;
         submitAction: (selectedIds: string[]) => Promise<void>;
+        intermediateApproveAction: (selectedIds: string[]) => Promise<void>;
+        intermediateUnapproveAction: (selectedIds: string[]) => Promise<void>;
     };
 };
 
@@ -181,6 +183,50 @@ export function useDataApprovalActions(props: {
         [compositionRoot.malDataApproval, reload, loading, log, dataSetsConfig]
     );
 
+    const intermediateApproveAction = useCallback(
+        async (selectedIds: string[]) => {
+            const items = _.compact(selectedIds.map(item => parseDataDuplicationItemId(item)));
+            if (items.length === 0) return;
+            loading.show(true, i18n.t("Applying intermediate approval..."));
+            const result = await compositionRoot.malDataApproval.updateStatus({
+                items,
+                action: "intermediateApprove",
+                dataSetsConfig,
+            });
+            if (!result)
+                setGlobalMessage({
+                    type: "error",
+                    message: i18n.t("Error when trying to apply intermediate approval"),
+                });
+
+            reload();
+            loading.hide();
+        },
+        [compositionRoot.malDataApproval, reload, loading, dataSetsConfig]
+    );
+
+    const intermediateUnapproveAction = useCallback(
+        async (selectedIds: string[]) => {
+            const items = _.compact(selectedIds.map(item => parseDataDuplicationItemId(item)));
+            if (items.length === 0) return;
+            loading.show(true, i18n.t("Removing intermediate approval..."));
+            const result = await compositionRoot.malDataApproval.updateStatus({
+                items,
+                action: "intermediateUnapprove",
+                dataSetsConfig,
+            });
+            if (!result)
+                setGlobalMessage({
+                    type: "error",
+                    message: i18n.t("Error when trying to remove intermediate approval"),
+                });
+
+            reload();
+            loading.hide();
+        },
+        [compositionRoot.malDataApproval, reload, loading, dataSetsConfig]
+    );
+
     const closeDataDifferencesDialog = useCallback(() => {
         closeDialog();
         disableRevoke();
@@ -206,6 +252,8 @@ export function useDataApprovalActions(props: {
             incompleteAction: incompleteAction,
             revokeAction: revokeAction,
             submitAction: submitAction,
+            intermediateApproveAction: intermediateApproveAction,
+            intermediateUnapproveAction: intermediateUnapproveAction,
         },
     };
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalListColumns.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalListColumns.tsx
@@ -41,6 +41,23 @@ export function useDataApprovalListColumns() {
                 sortable: false,
                 getValue: row => (row.lastDateOfApproval ? i18n.t("Approved") : i18n.t("Not approved")),
             },
+            {
+                name: "effectiveIntermediateApproval",
+                text: i18n.t("Intermediate approval status"),
+                sortable: false,
+                hidden: true,
+                getValue: row => {
+                    switch (row.effectiveIntermediateApproval) {
+                        case "approved":
+                            return i18n.t("Approved");
+                        case "notApproved":
+                            return i18n.t("Not approved");
+                        case "na":
+                        default:
+                            return i18n.t("N/A");
+                    }
+                },
+            },
             { name: "modificationCount", text: i18n.t("Modification Count"), sortable: false },
             {
                 name: "lastUpdatedValue",


### PR DESCRIPTION
## Summary
Add an opt-in intermediate approval step per dataset. When enabled, a dataset requires an "Intermediate Approve" action to land before the existing final **Approve** action becomes available. When the flag is off, nothing changes — all existing workflows behave exactly as before.

Recorded decisions (all confirmed with the requester before implementation):
- **Storage**: new `intermediateApprovalRequired: boolean` and `intermediateApproveCode: string` fields on `DataSetConfiguration`. The code points at a Yes/No data element in the approval (APVD) dataset. The new actions write `"true"` / `"false"` to that data element with the default COC per (orgUnit, period), matching the existing Submit flow.
- **Read path**: one extra `/dataValueSets` call per item is joined in [GetMalDataSetsUseCase](src/domain/reports/mal-data-approval/usecases/GetMalDataSetsUseCase.ts) (SQL views untouched, per the option (b) we agreed on).
- **Effective state is derivational**: `effective = stored Yes AND modificationCount == 0`. If the source data is edited after an intermediate approval, the list automatically shows *Not approved* and gates the final Approve action — no side-effect writes to the server.
- **Approve gating**: the final Approve action is hidden whenever any selected row fails the intermediate gate (covers both single-row and partial-multi-select cases).
- **Revoke cascade**: running Revoke on a dataset with intermediate approval also resets the stored intermediate flag to false, so the approval chain must be replayed from scratch.

## What's in the PR

**Configuration** ([DataSetConfigForm.tsx](src/webapp/components/dataset-config/DataSetConfigForm.tsx), [DataSetConfiguration.ts](src/domain/entities/DataSetConfiguration.ts))
- New *Intermediate approval required* checkbox.
- New *Intermediate Approve DataElement* selector (disabled until the flag is on — [EntitySelector.tsx](src/webapp/components/entity-selector/EntitySelector.tsx) gains a small \`disabled\` prop for that).
- New *Intermediate Approve* permission group — listed in \`dataSetConfigurationActions\`, rendered through the same permission-button loop so administrators can grant it to user groups / individual users. Super-admins bypass as with every other action.
- \`DataSetConfiguration.withDefaults\` keeps older stored configs backward-compatible: missing fields default to \`false\` / \`""\` and missing permission entries to the empty permission set. Applied in [DataSetConfigurationD2Repository.ts](src/data/DataSetConfigurationD2Repository.ts).

**List column** ([useDataApprovalListColumns.tsx](src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalListColumns.tsx))
- New *Intermediate approval status* column, \`hidden: true\` by default — the existing gear-icon column selector still controls visibility/persistence. Values: *Approved*, *Not approved*, *N/A* (when the flag is off for that dataset).

**View model derivation** ([DataApprovalViewModel.ts](src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts))
- Takes \`dataSetsConfig\` so it can read the per-dataset flag.
- Emits \`intermediateApprovalRequired\`, \`intermediateApproved\` (stored) and \`effectiveIntermediateApproval\` (derived) per row.

**Row actions** ([useActiveDataApprovalActions.tsx](src/webapp/reports/mal-data-approval/data-approval-list/hooks/useActiveDataApprovalActions.tsx), [useDataApprovalActions.tsx](src/webapp/reports/mal-data-approval/data-approval-list/hooks/useDataApprovalActions.tsx), [DataApprovalList.tsx](src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx))
- *Intermediate Approve* visible when: flag is on, user has permission, effective status is \`notApproved\`, row has data and a non-zero modification count. Multi-select supported.
- *Intermediate Unapprove* visible when: flag is on, user has permission, **stored** intermediate is Yes (unchanged by the modification mask), and the final approval has **not** been granted (you need Revoke first otherwise). Multi-select supported.
- Existing **Approve** action hidden when any selected row has effective intermediate status \`!= approved\`. When the flag is off, \`effective == "na"\` and Approve behaves as before.

**Data layer** ([MalDataApprovalRepository.ts](src/domain/reports/mal-data-approval/repositories/MalDataApprovalRepository.ts), [MalDataApprovalDefaultRepository.ts](src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts), [UpdateMalApprovalStatusUseCase.ts](src/domain/reports/mal-data-approval/usecases/UpdateMalApprovalStatusUseCase.ts), [GetMalDataSetsUseCase.ts](src/domain/reports/mal-data-approval/usecases/GetMalDataSetsUseCase.ts))
- \`setIntermediateApproval({ dataSets, dataSetConfig, approved })\` — POST to \`/dataValueSets.json\`.
- \`getIntermediateApproval({ item, dataSetConfig })\` — GET \`/dataValueSets\` and filter by data element id.
- Two new actions on \`UpdateMalApprovalStatusUseCase\`: \`intermediateApprove\` / \`intermediateUnapprove\`. The \`revoke\` branch now also calls \`setIntermediateApproval({ approved: false })\` when the dataset has the flag on.
- \`GetMalDataSetsUseCase\` joins the stored intermediate value into each item alongside the existing modification count.

**Docs** ([docs/data-approval-user-guide.md](docs/data-approval-user-guide.md))
- Full user guide for the app (list columns, filters, analytics-running notice, contextual actions, dataset config, permission groups, intermediate approval, DataElementGroups flag). The previous docs PR (#8) covered the non-intermediate parts; this PR rewrites the same file with everything. Whichever PR merges last will need a trivial rebase.

## Test plan
- [ ] Create a dataset config with **Intermediate approval required** *off*. List column should read *N/A*, Approve should behave exactly as before, no new actions visible.
- [ ] Turn the flag on and point *Intermediate Approve DataElement* at a boolean DE in the APVD dataset. Grant *Intermediate Approve* to a user group, grant *Approve* to a different user group. Save the config.
- [ ] As a user in the *Intermediate Approve* group: verify *Intermediate Approve* appears, *Approve* is hidden. Run *Intermediate Approve* on a row; *Intermediate approval status* flips to *Approved* and *Approve* remains hidden (no permission). *Intermediate Unapprove* now appears.
- [ ] As a user in the *Approve* group: verify *Approve* is visible only on rows where effective intermediate status is *Approved*.
- [ ] Multi-select a mix of intermediate-approved and not-approved rows; *Approve* should be hidden.
- [ ] After an intermediate approval, have a data-entry user modify a source value so the modification count becomes > 0. Refresh the list: *Intermediate approval status* should flip back to *Not approved*, *Approve* should disappear, and re-running *Intermediate Approve* should restore the *Approved* state.
- [ ] On a row with final *Approve* granted: run *Revoke*. Both the approval and the stored intermediate value should reset to *No*; *Intermediate approval status* should show *Not approved* after reload.
- [ ] Load an **existing** dataset configuration (from before this PR) — it should open in the form with the new flag unchecked, no errors, and no permission gaps.

## Known limitations
- The per-item \`/dataValueSets\` call adds one extra request per row when the flag is on. That matches the existing per-item diff-fetch pattern and should be fine for the list page sizes the app uses (10–50 rows) but is not batched — worth revisiting if we see perf regressions on busy deployments.
- The d2-ui-components \`TableAction\` type does not support a "disabled with tooltip" state; the gate is implemented by hiding the Approve action via \`isActive\`. We briefly considered a snackbar-on-click fallback to explain *why* Approve is missing, but chose to keep the behavior simple and document it in the user guide instead.
- A couple of pre-existing \`tsc --noEmit\` errors remain in the repo (d2-api module not re-exporting \`D2Api\` etc.); they exist on master and are unrelated to this PR. \`react-scripts build\` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)