### PR TITLE
Allow Personal Access Tokens in setup scripts (2FA support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ REACT_APP_DHIS2_BASE_URL=http://localhost:8080
 REACT_APP_DHIS2_AUTH=admin:district
 ```
 
+### Authenticating against an instance with 2FA
+
+When the target DHIS2 instance has two-factor authentication enabled and plain `username:password` no longer works from the CLI, the setup scripts (`yarn run generate-dataset-approval`, `yarn run generate-sqlviews`) also accept a **Personal Access Token** via `REACT_APP_DHIS2_PAT`. PATs bypass 2FA on DHIS2 API requests.
+
+1.  In DHIS2, open your user profile → *Edit profile* → *Personal access tokens* and create a new token. Copy it — DHIS2 only shows it once.
+2.  Add it to `.env.local` and drop `REACT_APP_DHIS2_AUTH`:
+
+    ```
+    REACT_APP_DHIS2_BASE_URL=https://your.dhis2
+    REACT_APP_DHIS2_PAT=d2pat_XXXXXXXXXXXXXXXXXXXX
+    ```
+
+When both variables are set, the scripts prefer the PAT.
+
 ## Development
 
 Start the development server at `http://localhost:8082` using `https://play.dhis2.org/2.34` as a backend:

--- a/src/scripts/common/d2ApiAuth.ts
+++ b/src/scripts/common/d2ApiAuth.ts
@@ -1,0 +1,24 @@
+type BasicAuth = { username: string; password: string };
+type PatAuth = { type: "personalToken"; token: string };
+type D2ApiAuth = BasicAuth | PatAuth;
+
+// Resolves the DHIS2 credentials a CLI script should use. Prefers a Personal
+// Access Token (REACT_APP_DHIS2_PAT) when set, which is the option that works
+// on instances where the user has 2FA enabled — PATs bypass 2FA on the API.
+// Falls back to REACT_APP_DHIS2_AUTH in the historical "username:password"
+// format when no PAT is provided.
+export function resolveD2ApiAuth(): D2ApiAuth {
+    const pat = process.env.REACT_APP_DHIS2_PAT;
+    if (pat) return { type: "personalToken", token: pat };
+
+    const authString = process.env.REACT_APP_DHIS2_AUTH || "";
+    const [username, password] = authString.split(":", 2);
+    if (!username || !password) {
+        throw new Error(
+            "Invalid DHIS2 authentication. Set REACT_APP_DHIS2_PAT to a Personal Access Token, " +
+                "or REACT_APP_DHIS2_AUTH to 'username:password'."
+        );
+    }
+
+    return { username, password };
+}

--- a/src/scripts/generate-dataset-approval.ts
+++ b/src/scripts/generate-dataset-approval.ts
@@ -6,6 +6,7 @@ import { ArgumentParser } from "argparse";
 import { getUidFromSeed } from "../utils/uid";
 import { getInChunks } from "../utils/promises";
 import { DATA_ELEMENT_SUFFIX } from "../domain/common/entities/AppSettings";
+import { resolveD2ApiAuth } from "./common/d2ApiAuth";
 
 const SUFFIX = DATA_ELEMENT_SUFFIX;
 const MAX_SHORT_NAME_LENGTH = 50;
@@ -40,12 +41,9 @@ async function main() {
     try {
         const args = parser.parse_args();
         const baseUrl = process.env.REACT_APP_DHIS2_BASE_URL || "";
-        const authString = process.env.REACT_APP_DHIS2_AUTH || "";
+        const auth = resolveD2ApiAuth();
 
-        const [username, password] = authString.split(":", 2);
-        if (!username || !password) throw new Error("Invalid DHIS2 authentication");
-
-        const api = new D2Api({ agent: {}, baseUrl, auth: { username, password } });
+        const api = new D2Api({ agent: {}, baseUrl, auth });
 
         await generateDataSetApproval({
             api,

--- a/src/scripts/generate-sqlviews.ts
+++ b/src/scripts/generate-sqlviews.ts
@@ -8,6 +8,7 @@ import { DataSetConfiguration } from "../domain/entities/DataSetConfiguration";
 import { DataSetConfigurationD2Repository } from "../data/DataSetConfigurationD2Repository";
 import { UserD2Repository } from "../data/UserD2Repository";
 import { SaveDataSetConfigurationUseCase } from "../domain/usecases/SaveDataSetConfigurationUseCase";
+import { resolveD2ApiAuth } from "./common/d2ApiAuth";
 
 const persistOptions = ["disk", "dhis"] as const;
 type PersistOption = typeof persistOptions[number];
@@ -46,10 +47,7 @@ async function main() {
     try {
         const args = parser.parse_args();
         const baseUrl = process.env.REACT_APP_DHIS2_BASE_URL || "";
-        const authString = process.env.REACT_APP_DHIS2_AUTH || "";
-
-        const [username, password] = authString.split(":", 2);
-        if (!username || !password) throw new Error("Invalid DHIS2 authentication");
+        const auth = resolveD2ApiAuth();
 
         const persistOption = persistOptions.find(po => po === args.persist);
         if (!persistOption)
@@ -57,7 +55,7 @@ async function main() {
                 `Invalid persist option: '${args.persist}'. Valid options are: ${persistOptions.join(", ")}`
             );
 
-        const api = new D2Api({ agent: {}, baseUrl, auth: { username, password } });
+        const api = new D2Api({ agent: {}, baseUrl, auth });
 
         await generateSqlViews({
             api,


### PR DESCRIPTION
## Summary
The two setup scripts used to bootstrap a dataset in Data Approval Extended — \`yarn run generate-dataset-approval\` and \`yarn run generate-sqlviews\` — previously only accepted \`REACT_APP_DHIS2_AUTH=username:password\` and built basic-auth \`D2Api\` instances from it. On DHIS2 instances where the target user has 2FA enabled this path stops working, so operators cannot use the scripts against those instances at all.

This PR teaches both scripts to additionally accept a **Personal Access Token** via a new \`REACT_APP_DHIS2_PAT\` env var. PATs bypass 2FA on the DHIS2 API, which is the standard answer for non-interactive CLI auth on 2FA-enabled users. The underlying \`@eyeseetea/d2-api\` already supports \`{ type: "personalToken", token }\` auth (see [node_modules/@eyeseetea/d2-api/api/types.d.ts:12-19](node_modules/@eyeseetea/d2-api/api/types.d.ts#L12-L19)) — this PR just exposes it at the CLI layer.

## Changes
- Add [src/scripts/common/d2ApiAuth.ts](src/scripts/common/d2ApiAuth.ts) with a tiny \`resolveD2ApiAuth()\` helper. It returns a PAT auth object when \`REACT_APP_DHIS2_PAT\` is set and falls back to the existing \`username:password\` parsing of \`REACT_APP_DHIS2_AUTH\` otherwise. The error message lists both variables so a missing-env failure is self-explanatory.
- Wire the helper into [src/scripts/generate-sqlviews.ts](src/scripts/generate-sqlviews.ts) and [src/scripts/generate-dataset-approval.ts](src/scripts/generate-dataset-approval.ts), replacing the inlined \`authString.split(":")\` blocks.
- Document \`REACT_APP_DHIS2_PAT\` in [README.md](README.md), next to the existing \`.env.local\` example, with a short \"Authenticating against an instance with 2FA\" subsection that walks the user through creating the token from their DHIS2 profile and dropping it into \`.env.local\`.

When both variables are set, the scripts prefer the PAT. When neither is set, the scripts fail fast with a message naming both variables.

### Out of scope
- \`approve-mal-datavalues\`, \`check-data-differences\` and \`post-metadata\` still use the old basic-auth-only parsing. They can be migrated in a follow-up by replacing their auth block with a \`resolveD2ApiAuth()\` call — I left them alone to keep the PR tight. Happy to include them if you prefer.

## Test plan
- [ ] With \`REACT_APP_DHIS2_PAT\` set (and \`REACT_APP_DHIS2_AUTH\` unset), run \`yarn run generate-sqlviews --dataSet ... --dataSet-destination ... --dataElement-submission ... --dataElement-approval ... --persist disk\` against a 2FA-enabled DHIS2 instance and confirm it no longer fails at the auth step.
- [ ] Repeat with \`yarn run generate-dataset-approval --dataSet ... --dataElement-submission ... --dataElement-approval ...\` (dry-run, no \`--post\`) and confirm it authenticates.
- [ ] Regression: with only \`REACT_APP_DHIS2_AUTH=admin:district\` set (no PAT), run the same two scripts against a non-2FA instance and confirm the existing basic-auth flow still works.
- [ ] Regression: with **neither** var set, confirm both scripts fail immediately with the new error message that lists both variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)