### PR TITLE
Limit OrgUnit filter tree to user's Data Capture org units

### DIFF
--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -165,7 +165,6 @@ export class Dhis2ConfigRepository implements ConfigRepository {
                     id: true,
                     displayName: true,
                     organisationUnits: userOrgUnitFields,
-                    dataViewOrganisationUnits: userOrgUnitFields,
                     userCredentials: {
                         username: true,
                         userRoles: { id: true, name: true, authorities: true },
@@ -175,14 +174,9 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             })
             .getData();
 
-        const viewOrgUnits = d2User.dataViewOrganisationUnits.map(ou => ({ ...ou, children: ou.children }));
-        const writeOrgUnits = d2User.organisationUnits.map(ou => ({ ...ou, children: ou.children }));
-
-        const orgUnits = _(viewOrgUnits)
-            .concat(writeOrgUnits)
-            .filter(ou => ou.level <= 3)
-            .unionBy(ou => ou.id)
-            .value();
+        const orgUnits = d2User.organisationUnits
+            .map(ou => ({ ...ou, children: ou.children }))
+            .filter(ou => ou.level <= 3);
 
         return {
             id: d2User.id,


### PR DESCRIPTION
## Summary
- The OrgUnit filter tree in the MAL data-approval report was being seeded from the **union** of `organisationUnits` (Data Capture) and `dataViewOrganisationUnits` (Data View) returned by `/me`, which could widen the tree beyond the user's assigned capture scope.
- This PR switches `Dhis2ConfigRepository.getCurrentUser()` to build `currentUser.orgUnits` from **Data Capture only**, so the tree reflects the set the user is actually authorized to approve against.
- The existing `level <= 3` cap on roots is preserved (out of scope for this change).

## Test plan
- [ ] Log in as a user whose Data View OUs are wider than their Data Capture OUs and confirm the OU filter tree in the MAL data-approval report only shows the Data Capture roots.
- [ ] Log in as a user whose Data View OUs are equal to their Data Capture OUs and confirm no visible regression.
- [ ] Log in as an admin (ALL authority) and confirm the tree still renders.
- [ ] Confirm approve/unapprove actions continue to behave correctly for OUs inside the Data Capture scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)