### PR TITLE
Release 1.0.1: limit OrgUnit tree to Data Capture scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "data-approval-extended",
     "description": "Data Approval Extended",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.1",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -165,7 +165,6 @@ export class Dhis2ConfigRepository implements ConfigRepository {
                     id: true,
                     displayName: true,
                     organisationUnits: userOrgUnitFields,
-                    dataViewOrganisationUnits: userOrgUnitFields,
                     userCredentials: {
                         username: true,
                         userRoles: { id: true, name: true, authorities: true },
@@ -175,14 +174,9 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             })
             .getData();
 
-        const viewOrgUnits = d2User.dataViewOrganisationUnits.map(ou => ({ ...ou, children: ou.children }));
-        const writeOrgUnits = d2User.organisationUnits.map(ou => ({ ...ou, children: ou.children }));
-
-        const orgUnits = _(viewOrgUnits)
-            .concat(writeOrgUnits)
-            .filter(ou => ou.level <= 3)
-            .unionBy(ou => ou.id)
-            .value();
+        const orgUnits = d2User.organisationUnits
+            .map(ou => ({ ...ou, children: ou.children }))
+            .filter(ou => ou.level <= 3);
 
         return {
             id: d2User.id,


### PR DESCRIPTION
## Summary
Merges development into master for the 1.0.1 release.

Included changes:
- **Limit OrgUnit filter tree to user's Data Capture org units** ([#16](https://github.com/EyeSeeTea/data-approval-dev/pull/16)) — the data-approval OU filter is now seeded from `organisationUnits` only (Data Capture), instead of the union with `dataViewOrganisationUnits`, so the tree reflects the scope the user is actually authorized to approve against. The existing `level <= 3` cap on roots is preserved.
- Version bump `1.0.0-beta.1` → `1.0.1`.

## Test plan
- [ ] Log in as a user whose Data View OUs are wider than their Data Capture OUs; confirm the OU filter tree in the MAL data-approval report only shows the Data Capture roots.
- [ ] Log in as an admin (`ALL` authority); confirm the tree still renders.
- [ ] Confirm approve/unapprove actions continue to behave correctly for OUs inside the Data Capture scope.
- [ ] Verify `package.json` version reads `1.0.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)